### PR TITLE
Support HTTPS by parameterizing the protocol for the HTTP requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The following is an example running a test against a remote Fedora deployed unde
 ./jmeter -Dfedora_4_server=52.90.98.146 -Dfedora_4_context=fcrepo/rest -n -t fedora.jmx
 ```
 
+If Fedora is deployed using HTTPS, specify the protocol and port on the command line:
+```bash
+./jmeter -Dfedora_4_protocol=https -Dfedora_4_port=8443 -Dfedora_4_server=<default=localhost> -Dfedora_4_context=<default=rest> -n -t <path/to/fcrepo4-jmeter>/fedora.jmx
+```
+
 ### Running specific performance tests
 
 This JMeter configuration can be used for several of the [test plans](https://wiki.duraspace.org/display/FF/Performance+and+Scalability+Test+Plans)

--- a/fedora.jmx
+++ b/fedora.jmx
@@ -67,6 +67,11 @@
             <stringProp name="Argument.value">3</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="FEDORA_4_SERVER_PROTOCOL" elementType="Argument">
+            <stringProp name="Argument.name">FEDORA_4_SERVER_PROTOCOL</stringProp>
+            <stringProp name="Argument.value">${__property(fedora_4_protocol,,http)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </elementProp>
       <stringProp name="TestPlan.user_define_classpath"></stringProp>
@@ -95,7 +100,7 @@
           <stringProp name="HTTPSampler.port">${FEDORA_4_SERVER_PORT}</stringProp>
           <stringProp name="HTTPSampler.connect_timeout"></stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
-          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.protocol">${FEDORA_4_SERVER_PROTOCOL}</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
           <stringProp name="HTTPSampler.path"></stringProp>
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
@@ -211,7 +216,7 @@ if (elapsed &gt; threshold) {
           <stringProp name="HTTPSampler.port">${FEDORA_4_SERVER_PORT}</stringProp>
           <stringProp name="HTTPSampler.connect_timeout"></stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
-          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.protocol">${FEDORA_4_SERVER_PROTOCOL}</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
           <stringProp name="HTTPSampler.path"></stringProp>
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
@@ -430,7 +435,7 @@ vars.put(&quot;post_body&quot;, RandomStringUtils.randomAscii(size));
           <stringProp name="HTTPSampler.port">${FEDORA_4_SERVER_PORT}</stringProp>
           <stringProp name="HTTPSampler.connect_timeout"></stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
-          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.protocol">${FEDORA_4_SERVER_PROTOCOL}</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
           <stringProp name="HTTPSampler.path">${FEDORA_4_SERVER_CONTEXT}/perf/${random_resource}</stringProp>
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>


### PR DESCRIPTION
Command line parameter name is "fedora_4_protocol" and it defaults to "http". Set to "https" (and set "fedora_4_port" appropriately) to use HTTPS connections.
